### PR TITLE
Refactor invoice controller

### DIFF
--- a/app/Domain/Invoices/Factories/CreateInvoice.php
+++ b/app/Domain/Invoices/Factories/CreateInvoice.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Invoices\Factories;
+
+use App\Models\Invoice;
+
+final class CreateInvoice
+{
+    /**
+     * @param array{
+     *  name: string,
+     *  governmentId: int,
+     *  email: string,
+     *  debtAmount: float,
+     *  debtDueDate: string,
+     *  debtId: string
+     * } $invoiceAttributes
+     */
+    public static function for(array $invoiceAttributes): Invoice
+    {
+        return Invoice::create([
+            'name' => $invoiceAttributes['name'],
+            'government_id' => $invoiceAttributes['governmentId'],
+            'email' => $invoiceAttributes['email'],
+            'debt_amount' => $invoiceAttributes['debtAmount'],
+            'debt_due_date' => $invoiceAttributes['debtDueDate'],
+            'debt_id' => $invoiceAttributes['debtId'],
+        ]);
+    }
+}

--- a/app/Domain/Invoices/Services/CreateInvoicesFromFile.php
+++ b/app/Domain/Invoices/Services/CreateInvoicesFromFile.php
@@ -14,14 +14,14 @@ final class CreateInvoicesFromFile
     /*
      * A better, more scalable and extendable approach for the long run would be to
      * rely on domain events. That way, we could add functionality with ease.
-     * For example, one line of the file fails, we could send an event that could be 
+     * For example, one line of the file fails, we could send an event that could be
      * handled by any number of listeners (one for logging, one for notifiying someone, etc.)
      */
     public static function process(UploadedFile $file): void
     {
         $fileReader = Reader::createFromPath($file->getRealPath(), 'r');
         $fileReader->setHeaderOffset(0);
-        
+
         /**
          * @var array{
          *  name: string,

--- a/app/Domain/Invoices/Services/CreateInvoicesFromFile.php
+++ b/app/Domain/Invoices/Services/CreateInvoicesFromFile.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Invoices\Services;
+
+use App\Domain\Invoices\Factories\CreateInvoice;
+use App\Domain\Invoices\Validators\InvoiceValidator;
+use Illuminate\Http\UploadedFile;
+use League\Csv\Reader;
+
+final class CreateInvoicesFromFile
+{
+    /*
+     * A better, more scalable and extendable approach for the long run would be to
+     * rely on domain events. That way, we could add functionality with ease.
+     * For example, one line of the file fails, we could send an event that could be 
+     * handled by any number of listeners (one for logging, one for notifiying someone, etc.)
+     */
+    public static function process(UploadedFile $file): void
+    {
+        $fileReader = Reader::createFromPath($file->getRealPath(), 'r');
+        $fileReader->setHeaderOffset(0);
+        
+        /**
+         * @var array{
+         *  name: string,
+         *  governmentId: int,
+         *  email: string,
+         *  debtAmount: float,
+         *  debtDueDate: string,
+         *  debtId: string
+         * } $invoiceAttributes
+         */
+        foreach ($fileReader as $invoiceAttributes) {
+            $invoiceValidator = InvoiceValidator::make($invoiceAttributes);
+
+            if ($invoiceValidator->fails()) {
+                continue;
+            }
+
+            CreateInvoice::for($invoiceAttributes);
+        }
+    }
+}

--- a/app/Domain/Invoices/Validators/InvoiceValidator.php
+++ b/app/Domain/Invoices/Validators/InvoiceValidator.php
@@ -9,7 +9,7 @@ use Illuminate\Validation\Validator;
 
 final class InvoiceValidator
 {
-    /** @var array<string, string>  $rules */
+    /** @var array<string, string> */
     protected static array $rules = [
         'name' => 'required|string',
         'governmentId' => 'required|numeric',

--- a/app/Domain/Invoices/Validators/InvoiceValidator.php
+++ b/app/Domain/Invoices/Validators/InvoiceValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Invoices\Validators;
+
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+use Illuminate\Validation\Validator;
+
+final class InvoiceValidator
+{
+    /** @var array<string, string>  $rules */
+    protected static array $rules = [
+        'name' => 'required|string',
+        'governmentId' => 'required|numeric',
+        'email' => 'required|email',
+        'debtAmount' => 'required|numeric',
+        'debtDueDate' => 'required|date',
+        'debtId' => 'required|string',
+    ];
+
+    /**
+     * @param array{
+     *  name: string,
+     *  governmentId: int,
+     *  email: string,
+     *  debtAmount: float,
+     *  debtDueDate: string,
+     *  debtId: string
+     * } $invoiceAttributes
+     */
+    public static function make(array $invoiceAttributes): Validator
+    {
+        return ValidatorFacade::make($invoiceAttributes, self::$rules);
+    }
+}

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\StoreInvoiceRequest;
 use App\Models\Invoice;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -28,8 +29,10 @@ class InvoiceController extends Controller
         }
     }
 
-    public function store(Request $request): JsonResponse
+    public function store(StoreInvoiceRequest $request): JsonResponse
     {
+        $validated = $request->validated();
+
         try {
             /** @var UploadedFile */
             $file = $request->file('csv_file');

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -2,17 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use App\Domain\Invoices\Factories\CreateInvoice;
 use App\Domain\Invoices\Services\CreateInvoicesFromFile;
-use App\Domain\Invoices\Validators\InvoiceValidator;
 use App\Http\Requests\InvoicesFileRequest;
 use App\Models\Invoice;
 use Exception;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\File;
-use League\Csv\Reader;
 use Resend;
 
 class InvoiceController extends Controller
@@ -43,7 +38,7 @@ class InvoiceController extends Controller
 
         /*
         * It's a good practice to process as much as possible, instead of throwing and halting
-        * the execution of the script. In this case, we could have a log of the errors and give 
+        * the execution of the script. In this case, we could have a log of the errors and give
         * the user a feedback only for the unprocessable invoices.
         */
 

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\StoreInvoiceRequest;
+use App\Http\Requests\InvoicesFileRequest;
 use App\Models\Invoice;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -29,7 +29,7 @@ class InvoiceController extends Controller
         }
     }
 
-    public function store(StoreInvoiceRequest $request): JsonResponse
+    public function store(InvoicesFileRequest $request): JsonResponse
     {
         $validated = $request->validated();
 

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -29,21 +29,8 @@ class InvoiceController extends Controller
     }
     public function store(Request $request)
     {
-        try {
-            if(!$request->hasFile('csv_file')){
-                return response()->json([
-                    'error' => 'File is required.'
-                ], 400);
-            }
-
+        try {            
             $file = $request->file('csv_file');
-
-            if($file->getClientOriginalExtension() != 'csv'){
-                return response()->json([
-                    'error' => 'Invalid csv file.'
-                ], 400);
-            }
-
             $filePath = $file->getRealPath();
             $csv = Reader::createFromPath($filePath, 'r');
             $csv->setHeaderOffset(0);

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -6,7 +6,6 @@ use App\Http\Requests\StoreInvoiceRequest;
 use App\Models\Invoice;
 use Exception;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Validator;
@@ -18,9 +17,10 @@ class InvoiceController extends Controller
     public function index(): JsonResponse
     {
         try {
-            $invoices = Invoice::all();
+            // Must explicitly order
+            $invoices = Invoice::orderBy('id', 'asc')->get();
 
-            return response()->json($invoices);
+            return response()->json(['invoices' => $invoices]);
         } catch (Exception $error) {
             return response()->json([
                 'error' => 'Error. Try again',

--- a/app/Http/Requests/InvoicesFileRequest.php
+++ b/app/Http/Requests/InvoicesFileRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class StoreInvoiceRequest extends FormRequest
+class InvoicesFileRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Requests/StoreInvoiceRequest.php
+++ b/app/Http/Requests/StoreInvoiceRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreInvoiceRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'csv_file' => 'required|file|mimes:csv,txt',
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'csv_file.required' => 'File is required.',
+            'csv_file.mimes' => 'Invalid csv file.',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreInvoiceRequest.php
+++ b/app/Http/Requests/StoreInvoiceRequest.php
@@ -20,7 +20,7 @@ class StoreInvoiceRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'csv_file' => 'required|file|mimes:csv,txt',
+            'csv_file' => 'required|file|mimetypes:csv,txt',
         ];
     }
 
@@ -31,7 +31,7 @@ class StoreInvoiceRequest extends FormRequest
     {
         return [
             'csv_file.required' => 'File is required.',
-            'csv_file.mimes' => 'Invalid csv file.',
+            'csv_file.mimetypes' => 'Invalid csv file.',
         ];
     }
 }

--- a/app/Http/Requests/StoreInvoiceRequest.php
+++ b/app/Http/Requests/StoreInvoiceRequest.php
@@ -15,7 +15,7 @@ class StoreInvoiceRequest extends FormRequest
     }
 
     /**
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     * @return array<string, string>
      */
     public function rules(): array
     {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "laravel/sail": "^1.18",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
+        "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.1",
         "spatie/laravel-ignition": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
-        ]
+        ],
+        "stan": "vendor/bin/phpstan analyse app tests"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
+        "larastan/larastan": "^2.6",
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.18",
         "mockery/mockery": "^1.4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3d170d2ee5abf03d8ec6bc959d8bac6",
+    "content-hash": "bb40d008155b94509f1246ce1271161f",
     "packages": [
         {
             "name": "brick/math",
@@ -5906,6 +5906,102 @@
             "time": "2020-07-09T08:09:16+00:00"
         },
         {
+            "name": "larastan/larastan",
+            "version": "v2.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "6c5e8820f3db6397546f3ce48520af9d312aed27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/6c5e8820f3db6397546f3ce48520af9d312aed27",
+                "reference": "6c5e8820f3db6397546f3ce48520af9d312aed27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^9.47.0 || ^10.0.0",
+                "illuminate/container": "^9.47.0 || ^10.0.0",
+                "illuminate/contracts": "^9.47.0 || ^10.0.0",
+                "illuminate/database": "^9.47.0 || ^10.0.0",
+                "illuminate/http": "^9.47.0 || ^10.0.0",
+                "illuminate/pipeline": "^9.47.0 || ^10.0.0",
+                "illuminate/support": "^9.47.0 || ^10.0.0",
+                "php": "^8.0.2",
+                "phpmyadmin/sql-parser": "^5.6.0",
+                "phpstan/phpstan": "~1.10.6"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.15.2",
+                "orchestra/testbench": "^7.19.0 || ^8.0.0",
+                "phpunit/phpunit": "^9.5.27"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NunoMaduro\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan wrapper for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v2.6.4"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2023-07-29T12:13:13+00:00"
+        },
+        {
             "name": "laravel/pint",
             "version": "v1.10.3",
             "source": {
@@ -6379,6 +6475,93 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpmyadmin/sql-parser",
+            "version": "5.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmyadmin/sql-parser.git",
+                "reference": "f1720ae19abe6294cb5599594a8a57bc3c8cc287"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/f1720ae19abe6294cb5599594a8a57bc3c8cc287",
+                "reference": "f1720ae19abe6294cb5599594a8a57bc3c8cc287",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "phpmyadmin/motranslator": "<3.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^1.1",
+                "phpmyadmin/coding-standard": "^3.0",
+                "phpmyadmin/motranslator": "^4.0 || ^5.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.9.12",
+                "phpstan/phpstan-phpunit": "^1.3.3",
+                "phpunit/php-code-coverage": "*",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.11",
+                "zumba/json-serializer": "~3.0.2"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance",
+                "phpmyadmin/motranslator": "Translate messages to your favorite locale"
+            },
+            "bin": [
+                "bin/highlight-query",
+                "bin/lint-query",
+                "bin/tokenize-query"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpMyAdmin\\SqlParser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The phpMyAdmin Team",
+                    "email": "developers@phpmyadmin.net",
+                    "homepage": "https://www.phpmyadmin.net/team/"
+                }
+            ],
+            "description": "A validating SQL lexer and parser with a focus on MySQL dialect.",
+            "homepage": "https://github.com/phpmyadmin/sql-parser",
+            "keywords": [
+                "analysis",
+                "lexer",
+                "parser",
+                "query linter",
+                "sql",
+                "sql lexer",
+                "sql linter",
+                "sql parser",
+                "sql syntax highlighter",
+                "sql tokenizer"
+            ],
+            "support": {
+                "issues": "https://github.com/phpmyadmin/sql-parser/issues",
+                "source": "https://github.com/phpmyadmin/sql-parser"
+            },
+            "funding": [
+                {
+                    "url": "https://www.phpmyadmin.net/donate/",
+                    "type": "other"
+                }
+            ],
+            "time": "2023-09-19T12:34:29+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee3fcb4876031d306c32fd102f06c611",
+    "content-hash": "a3d170d2ee5abf03d8ec6bc959d8bac6",
     "packages": [
         {
             "name": "brick/math",
@@ -6381,6 +6381,68 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "phpstan/phpstan",
+            "version": "1.10.50",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-13T10:59:42+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "10.1.2",
             "source": {
@@ -8149,5 +8211,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - ./vendor/larastan/larastan/extension.neon
+
+parameters:
+    checkGenericClassInNonGenericObjectType: false
+
+    level: 9

--- a/tests/Feature/InvoiceTest.php
+++ b/tests/Feature/InvoiceTest.php
@@ -2,17 +2,38 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use Illuminate\Testing\Fluent\AssertableJson;
 use App\Models\Invoice;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Response;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
 
 class InvoiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function testGetInvoices(){
+    public function test_it_fails_when_file_is_missing(): void
+    {
+        $response = $this->withHeaders(['Authorization' => 'Bearer xxxxxx'])->postJson('api/v1/invoices', []);
+    
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['csv_file' => 'File is required.']);
+    }
+
+    public function test_it_fails_when_file_type_is_invalid(): void
+    {
+        $response = $this->withHeaders(['Authorization' => 'Bearer xxxxxx'])
+            ->postJson('api/v1/invoices', [
+                'csv_file' => UploadedFile::fake()->image('avatar.jpg'),
+            ]);
+    
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['csv_file' => 'Invalid csv file.']);
+    }
+
+    public function testGetInvoices()
+    {
         Invoice::factory()->count(2)->create();
 
         $response = $this->withHeaders([
@@ -21,17 +42,16 @@ class InvoiceTest extends TestCase
 
         $response->assertStatus(200);
 
-        $response->assertJson(fn (AssertableJson $json) =>
-        $json->has(2)
-            ->first(fn (AssertableJson $json) =>
-                $json->hasAll(['name', 'government_id', 'email'])
-                    ->etc()
+        $response->assertJson(fn (AssertableJson $json) => $json->has(2)
+            ->first(fn (AssertableJson $json) => $json->hasAll(['name', 'government_id', 'email'])
+                ->etc()
             )
         );
-        
+
     }
 
-    public function testCreateInvoices(){
+    public function testCreateInvoices()
+    {
         $data = [
             'csv_file' => new \Illuminate\Http\UploadedFile(
                 resource_path('upload-teste.csv'),
@@ -39,7 +59,7 @@ class InvoiceTest extends TestCase
                 'text/csv',
                 null,
                 true
-            )
+            ),
         ];
 
         $response = $this->withHeaders([

--- a/tests/Unit/Domain/Invoices/Factories/CreateInvoiceTest.php
+++ b/tests/Unit/Domain/Invoices/Factories/CreateInvoiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Invoices\Factories;
+
+use App\Domain\Invoices\Factories\CreateInvoice;
+use App\Models\Invoice;
+use function fake;
+use Tests\TestCase;
+
+final class CreateInvoiceTest extends TestCase
+{
+    public function test_it_creates_an_invoice(): void
+    {
+        $invoiceAttributes = [
+            'name' => fake()->name,
+            'governmentId' => fake()->randomNumber(),
+            'email' => fake()->email,
+            'debtAmount' => fake()->randomFloat(2, 0, 1000),
+            'debtDueDate' => fake()->date,
+            'debtId' => fake()->uuid,
+        ];
+
+        $invoice = CreateInvoice::for($invoiceAttributes);
+
+        $this->assertDatabaseCount(Invoice::class, 1);
+        $this->assertDatabaseHas(Invoice::class, [
+            'name' => $invoiceAttributes['name'],
+            'government_id' => $invoiceAttributes['governmentId'],
+            'email' => $invoiceAttributes['email'],
+            'debt_amount' => $invoiceAttributes['debtAmount'],
+            'debt_due_date' => $invoiceAttributes['debtDueDate'],
+            'debt_id' => $invoiceAttributes['debtId'],
+        ]);
+    }
+}


### PR DESCRIPTION
@Lorenalgm

### Contexto

Tomei a liberdade de refatorar parte de um projeto público seu como uma _carta de apresentação_.
Não aceite o _merge_, tomei algumas liberdades para mostrar meu conhecimento de boas práticas, mas não repliquei as alterações para o resto do projeto, então algumas coisas podem quebrar, como por exemplo o retorno da lista de _invoices_, que antes era apenas um array, e agora é um objeto.

### Adicionado
- Análise estática usando o PHPStan no nível mais alto (os arquivos editados/criados estão todos em conformidade)
- Adicionada cobertura de testes de 100% para o _endpoint_ da lista de _invoices_ (GET /api/v1/invoices)
- Adicionada cobertura de testes de 100% para o _endpoint_ de criação de _invoices_ (POST /api/v1/invoices)

### Alterado
- Validação do envio do arquivo de _invoices_ foi movida para uma classe exclusiva
- Validação dos dados das _invoices_ foi movida para uma classe exclusiva
- Lógica de leitura do arquivo e criação das _invoices_ foi movida para um serviço
- Os arquivos editados/criados foram formatados usando os padrões da comunidade usando o [Laravel Pint](https://laravel.com/docs/10.x/pint)

### Corrigido
- O teste de envio do arquivo de _invoices_ criava e excluia um arquivo toda vez que os testes eram executados, poluindo o _stage_ do _git_. Esse teste foi corrigido para não mais acontecer isso.